### PR TITLE
Modify Loader to solve SQLite querying issue 

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Required fields + types are checked in the load stage by the database constraint
 
 ```commandline
 python3 main.py -f "data/dummy_meshes_with_errors.csv"
+python3 main.py -f "data/dummy_meshes_correct.csv"
 ```
 
 # Tests
@@ -29,3 +30,11 @@ pytest
 
 - In `test_keep_unique_codename`: having inplace=True modified the original fixture even when copied.
 - List of strings in SQLite -> replaced with PickleType
+- SQLite: I usually use Postgres but tried SQLite to not use a server. The issue was querying SQLite that I solved when replacing pd.to_sql with a more controlled insertion.
+- Decoding `roll_pallet` read from SQLite: element returned is b'\x1e\x00\x00\x00\x00\x00\x00\x00'. L'erreur vient de `roll_pallet` qui a une valeur négative, créé une fonction dans Transformer pour y remédier.
+
+# Improvements
+
+- Prendre en compte tous les cas d'usage lorsqu'il y a plus de données: prendre en main les NA et mauvaises entrées pour chaque colonne...
+- Utiliser Docker pour rendre le projet plus reproductible
+- Tester Loader

--- a/config/definitions.py
+++ b/config/definitions.py
@@ -1,5 +1,5 @@
-
 DB_STRING = 'sqlite:///meshes.db'
+
 
 class Fields:
     codename = 'codename'

--- a/processor/loader/loader.py
+++ b/processor/loader/loader.py
@@ -1,10 +1,12 @@
 from sqlalchemy import create_engine
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import sessionmaker
-from sqlalchemy import select
-from config.db_schema import Meshes
+import pandas as pd
+import struct
 
+from config.db_schema import Meshes
 from config.db_schema import Base
-from config.definitions import DB_STRING
+from config.definitions import DB_STRING, Fields
 
 
 class Loader:
@@ -17,8 +19,33 @@ class Loader:
         Base.metadata.bind = self.engine
 
     def load(self, meshes):
-        print(type(meshes))
-        meshes.to_sql('meshes', con=self.engine, if_exists='replace', index=False)
+        session = self.db_session()
+
+        for i in range(len(meshes)):
+            codename = meshes.loc[i, Fields.codename]
+            trame = meshes.loc[i, Fields.trame]
+            mass_surf = meshes.loc[i, Fields.mass_surf]
+            is_compat_interior_wall = meshes.loc[i, Fields.is_compat_interior_wall]
+            mesh_height = meshes.loc[i, Fields.mesh_height]
+            mesh_width = meshes.loc[i, Fields.mesh_width]
+            roll_pallet = meshes.loc[i, Fields.roll_pallet]
+            color_names = meshes.loc[i, Fields.color_names]
+
+            try:
+                session.add(Meshes(
+                    codename=codename,
+                    trame=trame,
+                    mass_surf=mass_surf,
+                    is_compat_interior_wall=is_compat_interior_wall,
+                    mesh_height=mesh_height,
+                    mesh_width=mesh_width,
+                    roll_pallet=roll_pallet,
+                    color_names=color_names
+                ))
+                session.commit()
+            except IntegrityError as e:
+                print(f"Row already inserted: {e}")
+                session.rollback()
 
     def query(self):
         session = self.db_session()
@@ -26,8 +53,23 @@ class Loader:
         try:
             result = session.query(Meshes).all()
 
+            data = []
             for row in result:
-                print(row)
+                data.append([row.codename, row.trame, row.mass_surf, row.is_compat_interior_wall, row.mesh_height,
+                             row.mesh_width, row.roll_pallet, row.color_names])
+            print(data)
+
+            df = pd.DataFrame(data,
+                              columns=[Fields.codename,
+                                       Fields.trame,
+                                       Fields.mass_surf,
+                                       Fields.is_compat_interior_wall,
+                                       Fields.mesh_height,
+                                       Fields.mesh_width,
+                                       Fields.roll_pallet,
+                                       Fields.color_names
+                                       ])
+            print(df)
         except Exception as e:
             print(f"An error occurred: {e}")
         finally:

--- a/processor/transformer/transformer.py
+++ b/processor/transformer/transformer.py
@@ -33,7 +33,9 @@ class Transformer:
         self.meshes = self.filter_trame(self.meshes)
         self.meshes = self.filter_positive(self.meshes)
         self.meshes[Fields.is_compat_interior_wall] = self.meshes[Fields.is_compat_interior_wall].apply(self.replace_bool)
+        self.meshes[Fields.roll_pallet] = self.meshes[Fields.roll_pallet].apply(self.replace_negative_roll_pallet)
         self.meshes = self.meshes[self.meshes.color_names.apply(self.check_allowed_values)]
+        self.meshes = self.meshes.reset_index(drop=True)
 
     @staticmethod
     def keep_unique_codename(meshes):
@@ -53,12 +55,19 @@ class Transformer:
     @staticmethod
     def replace_bool(value):
         """Replace boolean values by Python boolean values."""
-        if value in ['FAUX', 'FALSE', '0']:
+        if value in ['FAUX', 'FALSE', 'false', '0']:
             return False
-        elif value in ['VRAI', 'TRUE', '1']:
+        elif value in ['VRAI', 'TRUE', 'true', '1']:
             return True
         else:
             return value
+
+    @staticmethod
+    def replace_negative_roll_pallet(value):
+        """Replace negative values by NA"""
+        if value < 0:
+            return None
+        return value
 
     @staticmethod
     def check_allowed_values(string):


### PR DESCRIPTION
# Description

Querying after inserting with pandas' to_sql() returned an error.

# Changes made

Insertion to DB is explicited with a Session.
IntegrityError is handled when the row already exists.
Querying is made through a another Session and resulted formatted in a DataFrame.
`roll_pallet` negative values are replaced with NA

# Checks

Tests are passed
Output seems correct with both csv files.